### PR TITLE
feat: add keyword field to PatentGenerateRequest

### DIFF
--- a/app/api/routes/patent.py
+++ b/app/api/routes/patent.py
@@ -9,7 +9,7 @@ from sse_starlette.sse import EventSourceResponse
 from app.api.schemas.request import PatentGenerateRequest, PatentSearchRequest
 from app.api.schemas.response import PatentGenerateResponse, PatentSearchResponse
 from app.config import Settings, get_settings
-from app.models.state import AgentState
+from app.models.state import build_initial_state
 from app.services.patent_searcher import PatentSearcher
 from app.services.patent_service import PatentService
 from app.services.reasoning_agent import PatentPipeline
@@ -39,6 +39,7 @@ async def generate_patent(
     try:
         return await service.generate(
             problem_description=request.problem_description,
+            keyword=request.keyword,
             technical_field=request.technical_field,
             max_evasion_attempts=request.max_evasion_attempts,
         )
@@ -54,24 +55,12 @@ async def generate_patent_stream(
 ):
     """SSE endpoint that streams step-by-step LangGraph state updates."""
 
-    initial_state: AgentState = {
-        "user_problem": request.problem_description,
-        "technical_field": request.technical_field or "",
-        "triz_principles": [],
-        "current_idea": "",
-        "similar_patents": [],
-        "max_similarity_score": 0.0,
-        "novelty_score": 0.0,
-        "novelty_reasoning": "",
-        "context_sufficient": False,
-        "evasion_count": 0,
-        "max_evasion_attempts": request.max_evasion_attempts,
-        "final_idea": "",
-        "reasoning_trace": [],
-        "current_step": "",
-        "patent_draft": None,
-        "docx_path": None,
-    }
+    initial_state = build_initial_state(
+        problem_description=request.problem_description,
+        keyword=request.keyword or "",
+        technical_field=request.technical_field or "",
+        max_evasion_attempts=request.max_evasion_attempts,
+    )
 
     async def event_generator():
         accumulated = dict(initial_state)

--- a/app/api/schemas/request.py
+++ b/app/api/schemas/request.py
@@ -1,9 +1,12 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class PatentGenerateRequest(BaseModel):
     problem_description: str = Field(
-        min_length=1, description="기술적 모순 또는 해결하고 싶은 문제"
+        default="", description="기술적 모순 또는 해결하고 싶은 문제"
+    )
+    keyword: str | None = Field(
+        default=None, description="검색 키워드 (예: 방열 구조체)"
     )
     technical_field: str | None = Field(
         default=None, description="기술 분야 (예: 전자기기, 의료기기)"
@@ -11,6 +14,14 @@ class PatentGenerateRequest(BaseModel):
     max_evasion_attempts: int = Field(
         default=3, ge=1, le=5, description="최대 회피 설계 시도 횟수"
     )
+
+    @model_validator(mode="after")
+    def at_least_one_input(self) -> "PatentGenerateRequest":
+        if not self.problem_description.strip() and not self.keyword:
+            raise ValueError(
+                "keyword 또는 problem_description 중 하나는 반드시 입력해야 합니다."
+            )
+        return self
 
 
 class PatentSearchRequest(BaseModel):

--- a/app/models/state.py
+++ b/app/models/state.py
@@ -6,6 +6,7 @@ from app.models.triz import TRIZPrinciple
 
 class AgentState(TypedDict):
     user_problem: str
+    keyword: str
     technical_field: str
     triz_principles: list[TRIZPrinciple]
     current_idea: str
@@ -21,3 +22,31 @@ class AgentState(TypedDict):
     current_step: str
     patent_draft: PatentDraft | None
     docx_path: str | None
+
+
+def build_initial_state(
+    problem_description: str = "",
+    keyword: str = "",
+    technical_field: str = "",
+    max_evasion_attempts: int = 3,
+) -> AgentState:
+    """Build the initial AgentState dict for a pipeline run."""
+    return {
+        "user_problem": problem_description,
+        "keyword": keyword,
+        "technical_field": technical_field,
+        "triz_principles": [],
+        "current_idea": "",
+        "similar_patents": [],
+        "max_similarity_score": 0.0,
+        "novelty_score": 0.0,
+        "novelty_reasoning": "",
+        "context_sufficient": False,
+        "evasion_count": 0,
+        "max_evasion_attempts": max_evasion_attempts,
+        "final_idea": "",
+        "reasoning_trace": [],
+        "current_step": "",
+        "patent_draft": None,
+        "docx_path": None,
+    }

--- a/app/services/patent_service.py
+++ b/app/services/patent_service.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from app.api.schemas.response import PatentGenerateResponse
 from app.config import Settings
-from app.models.state import AgentState
+from app.models.state import build_initial_state
 from app.services.reasoning_agent import PatentPipeline
 
 logger = logging.getLogger(__name__)
@@ -16,28 +16,17 @@ class PatentService:
 
     async def generate(
         self,
-        problem_description: str,
+        problem_description: str = "",
+        keyword: str | None = None,
         technical_field: str | None = None,
         max_evasion_attempts: int = 3,
     ) -> PatentGenerateResponse:
-        initial_state: AgentState = {
-            "user_problem": problem_description,
-            "technical_field": technical_field or "",
-            "triz_principles": [],
-            "current_idea": "",
-            "similar_patents": [],
-            "max_similarity_score": 0.0,
-            "novelty_score": 0.0,
-            "novelty_reasoning": "",
-            "context_sufficient": False,
-            "evasion_count": 0,
-            "max_evasion_attempts": max_evasion_attempts,
-            "final_idea": "",
-            "reasoning_trace": [],
-            "current_step": "",
-            "patent_draft": None,
-            "docx_path": None,
-        }
+        initial_state = build_initial_state(
+            problem_description=problem_description,
+            keyword=keyword or "",
+            technical_field=technical_field or "",
+            max_evasion_attempts=max_evasion_attempts,
+        )
 
         final_state = await self.pipeline.run(initial_state)
 

--- a/app/services/reasoning_agent.py
+++ b/app/services/reasoning_agent.py
@@ -104,7 +104,10 @@ class PatentPipeline:
 
     async def _classify_triz_node(self, state: AgentState) -> dict:
         principles = await classify_triz(
-            state["user_problem"], state["technical_field"], self.settings
+            state["user_problem"],
+            state["technical_field"],
+            self.settings,
+            keyword=state.get("keyword"),
         )
         return {
             "triz_principles": principles,
@@ -115,6 +118,9 @@ class PatentPipeline:
 
     async def _search_internal_node(self, state: AgentState) -> dict:
         query = state["user_problem"]
+        keyword = state.get("keyword", "")
+        if keyword:
+            query = f"{keyword} {query}".strip()
         if state["current_idea"]:
             query = f"{query} {state['current_idea'][:200]}"
         results = await self.patent_searcher.search(query)
@@ -164,7 +170,7 @@ class PatentPipeline:
         }
 
     async def _search_kipris_node(self, state: AgentState) -> dict:
-        keyword = state["user_problem"][:50]
+        keyword = state.get("keyword") or state["user_problem"][:50]
         patents = await self.kipris_client.search_patents(keyword, num_of_rows=20)
         kipris_as_patents = [
             SimilarPatent(

--- a/app/services/triz_classifier.py
+++ b/app/services/triz_classifier.py
@@ -24,6 +24,7 @@ async def classify_triz(
     problem_description: str,
     technical_field: str,
     settings: Settings,
+    keyword: str | None = None,
 ) -> list[TRIZPrinciple]:
     """Classify problem into top-3 TRIZ principles using Gemini."""
     llm = ChatGoogleGenerativeAI(
@@ -42,11 +43,19 @@ async def classify_triz(
         ]
     ).partial(principles_list=principles_text)
 
+    # Combine keyword and problem_description for classification
+    combined_problem = problem_description
+    if keyword:
+        if combined_problem:
+            combined_problem = f"{combined_problem} (키워드: {keyword})"
+        else:
+            combined_problem = keyword
+
     field_context = f"기술 분야: {technical_field}" if technical_field else ""
     chain = prompt | llm
     response = await chain.ainvoke(
         {
-            "problem_description": problem_description,
+            "problem_description": combined_problem,
             "field_context": field_context,
         }
     )

--- a/frontend/src/components/PatentForm.tsx
+++ b/frontend/src/components/PatentForm.tsx
@@ -18,12 +18,14 @@ const TECHNICAL_FIELDS = [
 interface PatentFormProps {
   onSubmit: (data: {
     problem_description: string;
+    keyword?: string;
     technical_field?: string;
     max_evasion_attempts?: number;
   }) => void;
   isLoading?: boolean;
   initialValues?: {
     problem_description?: string;
+    keyword?: string;
     technical_field?: string;
     max_evasion_attempts?: number;
   } | null;
@@ -31,6 +33,7 @@ interface PatentFormProps {
 
 export function PatentForm({ onSubmit, isLoading, initialValues }: PatentFormProps) {
   const [problemDescription, setProblemDescription] = useState(initialValues?.problem_description ?? "");
+  const [keyword, setKeyword] = useState(initialValues?.keyword ?? "");
   const [technicalField, setTechnicalField] = useState(initialValues?.technical_field ?? "");
   const [maxEvasionAttempts, setMaxEvasionAttempts] = useState(initialValues?.max_evasion_attempts ?? 3);
   const [error, setError] = useState<string | null>(null);
@@ -39,14 +42,16 @@ export function PatentForm({ onSubmit, isLoading, initialValues }: PatentFormPro
     e.preventDefault();
     setError(null);
 
-    const trimmed = problemDescription.trim();
-    if (!trimmed) {
-      setError("문제 설명을 입력해 주세요.");
+    const trimmedProblem = problemDescription.trim();
+    const trimmedKeyword = keyword.trim();
+    if (!trimmedProblem && !trimmedKeyword) {
+      setError("문제 설명 또는 키워드 중 하나는 입력해 주세요.");
       return;
     }
 
     onSubmit({
-      problem_description: trimmed,
+      problem_description: trimmedProblem,
+      keyword: trimmedKeyword || undefined,
       technical_field: technicalField || undefined,
       max_evasion_attempts: maxEvasionAttempts,
     });
@@ -54,13 +59,32 @@ export function PatentForm({ onSubmit, isLoading, initialValues }: PatentFormPro
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Keyword */}
+      <div>
+        <label
+          htmlFor="keyword"
+          className="block text-label text-text-secondary mb-2"
+        >
+          키워드
+        </label>
+        <input
+          id="keyword"
+          type="text"
+          className="w-full rounded-lg border border-border-default bg-bg-primary px-4 py-3 text-body-m text-text-primary placeholder:text-text-tertiary focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder="검색 키워드를 입력하세요. 예: 방열 구조체"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          disabled={isLoading}
+        />
+      </div>
+
       {/* Problem Description */}
       <div>
         <label
           htmlFor="problem"
           className="block text-label text-text-secondary mb-2"
         >
-          문제 설명 <span className="text-error">*</span>
+          문제 설명
         </label>
         <Textarea
           id="problem"
@@ -69,7 +93,6 @@ export function PatentForm({ onSubmit, isLoading, initialValues }: PatentFormPro
           onChange={(e) => setProblemDescription(e.target.value)}
           aria-invalid={!!error}
           disabled={isLoading}
-          minLength={1}
         />
         {error && (
           <p className="mt-2 text-body-m text-error" role="alert">

--- a/frontend/src/types/patent.ts
+++ b/frontend/src/types/patent.ts
@@ -2,6 +2,7 @@
 
 export interface PatentGenerateRequest {
   problem_description: string;
+  keyword?: string;
   technical_field?: string;
   max_evasion_attempts?: number;
 }

--- a/tests/test_keyword_field.py
+++ b/tests/test_keyword_field.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import ValidationError
+
+from app.api.schemas.request import PatentGenerateRequest
+
+
+def test_keyword_only_request_valid():
+    req = PatentGenerateRequest(keyword="방열 구조체")
+    assert req.keyword == "방열 구조체"
+    assert req.problem_description == ""
+
+
+def test_description_only_request_valid():
+    req = PatentGenerateRequest(problem_description="발열을 줄이고 싶다")
+    assert req.problem_description == "발열을 줄이고 싶다"
+    assert req.keyword is None
+
+
+def test_both_provided_valid():
+    req = PatentGenerateRequest(
+        problem_description="발열 문제",
+        keyword="방열 구조체",
+    )
+    assert req.problem_description == "발열 문제"
+    assert req.keyword == "방열 구조체"
+
+
+def test_neither_provided_invalid():
+    with pytest.raises(ValidationError, match="keyword 또는 problem_description"):
+        PatentGenerateRequest()
+
+
+def test_empty_strings_invalid():
+    with pytest.raises(ValidationError, match="keyword 또는 problem_description"):
+        PatentGenerateRequest(problem_description="  ", keyword=None)
+
+
+def test_keyword_with_technical_field():
+    req = PatentGenerateRequest(
+        keyword="열방출 구조",
+        technical_field="전자기기",
+        max_evasion_attempts=2,
+    )
+    assert req.keyword == "열방출 구조"
+    assert req.technical_field == "전자기기"
+    assert req.max_evasion_attempts == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,6 +31,7 @@ def test_agent_state_keys():
 
     state: AgentState = {
         "user_problem": "test",
+        "keyword": "",
         "technical_field": "",
         "triz_principles": [],
         "current_idea": "",
@@ -51,3 +52,30 @@ def test_agent_state_keys():
     assert state["evasion_count"] == 0
     assert state["novelty_score"] == 0.0
     assert state["patent_draft"] is None
+    assert state["keyword"] == ""
+
+
+def test_build_initial_state():
+    from app.models.state import build_initial_state
+
+    state = build_initial_state(
+        problem_description="test problem",
+        keyword="방열",
+        technical_field="전자기기",
+        max_evasion_attempts=5,
+    )
+    assert state["user_problem"] == "test problem"
+    assert state["keyword"] == "방열"
+    assert state["technical_field"] == "전자기기"
+    assert state["max_evasion_attempts"] == 5
+    assert state["triz_principles"] == []
+    assert state["patent_draft"] is None
+
+
+def test_build_initial_state_defaults():
+    from app.models.state import build_initial_state
+
+    state = build_initial_state()
+    assert state["user_problem"] == ""
+    assert state["keyword"] == ""
+    assert state["max_evasion_attempts"] == 3

--- a/tests/test_patent_route.py
+++ b/tests/test_patent_route.py
@@ -16,7 +16,7 @@ def test_generate_endpoint_accepts_valid_request():
     assert response.status_code in (200, 500)
 
 
-def test_generate_endpoint_rejects_empty_description():
+def test_generate_endpoint_rejects_empty_inputs():
     from app.api.routes.patent import get_patent_service
     from app.main import app
 
@@ -27,13 +27,26 @@ def test_generate_endpoint_rejects_empty_description():
 
     try:
         client = TestClient(app)
+        # Both empty — should be rejected
         response = client.post(
             "/api/v1/patent/generate",
-            json={"problem_description": ""},
+            json={"problem_description": "", "keyword": None},
         )
         assert response.status_code == 422
     finally:
         app.dependency_overrides.clear()
+
+
+def test_generate_endpoint_accepts_keyword_only():
+    from app.main import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post(
+        "/api/v1/patent/generate",
+        json={"keyword": "방열 구조체"},
+    )
+    # Without valid API keys, will get 500, but request is valid (not 422)
+    assert response.status_code in (200, 500)
 
 
 def test_search_endpoint_accepts_valid_request():

--- a/tests/test_sse_stream.py
+++ b/tests/test_sse_stream.py
@@ -257,12 +257,12 @@ async def test_sse_happy_path():
 
 @pytest.mark.asyncio
 async def test_sse_empty_input_validation():
-    """Empty problem_description returns 422 validation error."""
+    """Empty problem_description and no keyword returns 422 validation error."""
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
             "/api/v1/patent/generate/stream",
-            json={"problem_description": ""},
+            json={"problem_description": "", "keyword": None},
         )
 
     assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add optional `keyword` field to `PatentGenerateRequest` alongside `problem_description`
- At least one of `keyword` or `problem_description` required (`model_validator`)
- Keyword used in TRIZ classification, hybrid search, and KIPRIS fallback
- Extract `build_initial_state()` helper to DRY initial state construction
- Frontend keyword input added to PatentForm
- TypeScript types synced with backend

## Test plan

- [x] `test_keyword_only_request_valid` — keyword alone accepted
- [x] `test_description_only_request_valid` — description alone accepted
- [x] `test_both_provided_valid` — both accepted
- [x] `test_neither_provided_invalid` — 422 when both empty
- [x] `test_build_initial_state` / `test_build_initial_state_defaults` — factory helper
- [x] `test_generate_endpoint_accepts_keyword_only` — route-level
- [x] `test_sse_empty_input_validation` — SSE rejects empty inputs
- [x] `ruff check .` passes
- [x] `npm run build` passes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)